### PR TITLE
check that expression.callee.property exists

### DIFF
--- a/lib/rules/no-unsafe-innerhtml.js
+++ b/lib/rules/no-unsafe-innerhtml.js
@@ -70,7 +70,7 @@ module.exports = function (context) {
             } else {
                 allowed = false;
             }
-        } else if (expression.type === "CallExpression") {
+        } else if ((expression.type === "CallExpression") && (expression.callee.property)) {
             var funcName = expression.callee.name || expression.callee.property.name;
             if (VALID_UNWRAPPERS.indexOf(funcName) !== -1) {
                 allowed = true;


### PR DESCRIPTION
added the following check to line 73 to ensure expression.callee.property exists before referencing it:

} else if ((expression.type === "CallExpression") **&& (expression.callee.property**)) {
            var funcName = expression.callee.name || expression.callee.property.name;
            if (VALID_UNWRAPPERS.indexOf(funcName) !== -1) {
                allowed = true;
            }