### PR TITLE
Bug expression.callee

### DIFF
--- a/lib/rules/no-unsafe-innerhtml.js
+++ b/lib/rules/no-unsafe-innerhtml.js
@@ -70,9 +70,9 @@ module.exports = function (context) {
             } else {
                 allowed = false;
             }
-        } else if ((expression.type === "CallExpression") && (expression.callee.property)) {
+        } else if ((expression.type === "CallExpression") && (expression.callee.property.name || expression.callee.name)) {
             var funcName = expression.callee.name || expression.callee.property.name;
-            if (VALID_UNWRAPPERS.indexOf(funcName) !== -1) {
+            if ( funcName && VALID_UNWRAPPERS.indexOf(funcName) !== -1) {
                 allowed = true;
             }
         } else if (expression.type === "BinaryExpression") {

--- a/lib/rules/no-unsafe-innerhtml.js
+++ b/lib/rules/no-unsafe-innerhtml.js
@@ -70,7 +70,7 @@ module.exports = function (context) {
             } else {
                 allowed = false;
             }
-        } else if (expression.type === "CallExpression") {
+        } else if ((expression.type === "CallExpression") && (expression.callee.property)) {
             var funcName = expression.callee.name || expression.callee.property.name;
             if (VALID_UNWRAPPERS.indexOf(funcName) !== -1) {
                 allowed = true;

--- a/lib/rules/no-unsafe-innerhtml.js
+++ b/lib/rules/no-unsafe-innerhtml.js
@@ -70,7 +70,7 @@ module.exports = function (context) {
             } else {
                 allowed = false;
             }
-        } else if ((expression.type === "CallExpression") && (expression.callee.property.name || expression.callee.name)) {
+        } else if ((expression.type === "CallExpression") && (expression.callee.property || expression.callee.name)) {
             var funcName = expression.callee.name || expression.callee.property.name;
             if ( funcName && VALID_UNWRAPPERS.indexOf(funcName) !== -1) {
                 allowed = true;


### PR DESCRIPTION
Opened up funcName to accept either values instead of just the property.name parameter by adding an OR condition

old method:
funcName can be callee.name or property.name.  this caused a failure if 'property' didn't exist so property.name couldn't be accessed

new method:
if either callee.name or property.name exist, then proceed with normal logic to assign one of these to funcName
