### PR TITLE
Allow linting of function invalid / unexpected arguments.

### DIFF
--- a/lib/rules/no-unsafe-innerhtml.js
+++ b/lib/rules/no-unsafe-innerhtml.js
@@ -118,7 +118,7 @@ module.exports = function (context) {
 
         CallExpression: function (node) {
             // this is for insertAdjacentHTML(position, markup)
-            if ("property" in node.callee) {
+            if ("property" in node.callee && node.arguments.length > 0) {
                 if (node.callee.property.name === "insertAdjacentHTML") {
                     if (!allowedExpression(node.arguments[1], node.parent)) {
                         context.report(node, "Unsafe call to insertAdjacentHTML");

--- a/tests/rules/no-unsafe-innerhtml.js
+++ b/tests/rules/no-unsafe-innerhtml.js
@@ -116,6 +116,10 @@ eslintTester.run("no-unsafe-innerhtml", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
         {
+            code: "document.write();",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
             code: "document.writeln(Sanitizer.escapeHTML`<em>${evil}</em>`);",
             parserOptions: { ecmaVersion: 6 }
         },


### PR DESCRIPTION
I discovered this while working on mozilla/addons-linter. I know that `document.write()` without an argument is theoretically wrong code but eslint doesn't validate this so we have to take care of that ourselves.

Let me know if I should fix this differently somehow or if you need more information about this.